### PR TITLE
fix: architecture of macos in apple silicon

### DIFF
--- a/gostun_install.sh
+++ b/gostun_install.sh
@@ -32,7 +32,7 @@ case $os in
       "i386" | "i686")
         wget -O gostun https://github.com/oneclickvirt/gostun/releases/download/output/gostun-darwin-386
         ;;
-      "armv7l" | "armv8" | "armv8l" | "aarch64")
+      "armv7l" | "armv8" | "armv8l" | "aarch64" | "arm64")
         wget -O gostun https://github.com/oneclickvirt/gostun/releases/download/output/gostun-darwin-arm64
         ;;
       *)


### PR DESCRIPTION
在M2处理器，14.5 (23F79)系统上运行`uname -m`的结果是`arm64`